### PR TITLE
Add data key to cache.writeData in resetCurrentGame

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ const stateLink = withClientState({
         cache.writeQuery({ query, data })
       },
       resetCurrentGame: (_, d, { cache }) => {
-        cache.writeData({ defaultState })
+        cache.writeData({ data : defaultState })
       }
     }
   }


### PR DESCRIPTION
Adding a score was generating a `Cannot read property 'selections' of null` error.