### PR TITLE
warning on resolver mutations- missing fields

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,9 +50,11 @@ const stateLink = withClientState({
         }
 
         cache.writeQuery({ query, data })
+        return null;
       },
       resetCurrentGame: (_, d, { cache }) => {
         cache.writeData({ data : defaultState })
+        return null;
       }
     }
   }


### PR DESCRIPTION
link-state mutations require you to return a null or an object,